### PR TITLE
Another metainfo hotfix

### DIFF
--- a/net.imaginaryinfinity.Squiid.json
+++ b/net.imaginaryinfinity.Squiid.json
@@ -41,8 +41,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://gitlab.com/ImaginaryInfinity/squiid-calculator/squiid/-/archive/1.1.3-flatpak-hotfix-2/squiid-1.1.3-flatpak-hotfix-2.tar.gz",
-                    "sha256": "20eca09b39b4afe4c66ab74c08a392900f572f7fb7669c82b2e1d9d07f26b626"
+                    "url": "https://gitlab.com/ImaginaryInfinity/squiid-calculator/squiid/-/archive/1.1.3-flatpak-hotfix-3/squiid-1.1.3-flatpak-hotfix-3.tar.gz",
+                    "sha256": "876963bea886cfd85e92c09bee490ff4aed3b09baa2c3543e0eabc61d6de597a"
                 },
                 "generated-sources.json"
             ]


### PR DESCRIPTION
The icon isn't being displayed on flathub. Hopefully this will fix it